### PR TITLE
docs: rewrite README and Contribution Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Gather the following about the alternative:
 
 ### Step 2: Add the Entry
 
-Open `src/data/alternatives.ts` and add your entry to the `alternatives` array:
+Open `src/data/manualAlternatives.ts` and add your entry to the `alternatives` array:
 
 ```typescript
 {
@@ -157,7 +157,7 @@ export type CategoryId =
   | 'your-new-category';
 ```
 
-### Step 2: Add the Category Definition
+### Step 2: Add the Category Definition and localization
 
 In `src/data/categories.ts`, add an entry to the `categories` array:
 
@@ -170,6 +170,11 @@ In `src/data/categories.ts`, add an entry to the `categories` array:
   emoji: '🔧',
 },
 ```
+
+In `src/i18n/locales/{de,en}/data.json`, add an entry to the `catagories`
+
+`"cloud-storage": { "name": "Cloud-Speicher", "description": "Dateispeicher- und Synchronisierungsdienste" },`
+`"cloud-storage": { "name": "Cloud Storage", "description": "File storage and sync services" },`
 
 ### Step 3: Update Filters (If Needed)
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ See [**CONTRIBUTING.md**](CONTRIBUTING.md) for the full guide, including:
 - Coding standards and commit conventions
 - Design system guidelines
 
-The fastest way to contribute: add or improve an entry in `data/research/master-research.md` and run `npm run generate:research`.
+The fastest way to contribute: add or improve an entry in `src/data/manualAlternatives` and run `npm run generate:research`.
 
 ## License
 


### PR DESCRIPTION
- [x] Adding a Category requires adding localization needs to be mentioned in the guide
- [x] Adding an Alternative is not done in: `src/data/alternatives.ts` but instead in `src/data/manualAlternatives.ts`

closes #36 