### PR TITLE
Proposal: Card Expansion as Overlay + Comparison Feature

### DIFF
--- a/src/components/AlternativeCard.tsx
+++ b/src/components/AlternativeCard.tsx
@@ -15,6 +15,8 @@ interface AlternativeCardProps {
   usVendorLookup: Map<string, Alternative>;
   onExpand?: (id: string) => void;
   overlayMode?: boolean;
+  isComparing?: boolean;
+  onToggleCompare?: (id: string) => void;
 }
 
 function getTrustBadgeClass(score: number): string {
@@ -95,7 +97,7 @@ function getOpenSourceBadgeConfig(openSourceLevel: OpenSourceLevel): { className
   }
 }
 
-export default function AlternativeCard({ alternative, viewMode, usVendorLookup, onExpand, overlayMode }: AlternativeCardProps) {
+export default function AlternativeCard({ alternative, viewMode, usVendorLookup, onExpand, overlayMode, isComparing, onToggleCompare }: AlternativeCardProps) {
   const { categories } = useCatalog();
   const [usVendorDetailsExpanded, setUsVendorDetailsExpanded] = useState(false);
   const [trustBreakdownExpanded, setTrustBreakdownExpanded] = useState(false);
@@ -472,22 +474,41 @@ export default function AlternativeCard({ alternative, viewMode, usVendorLookup,
       </div>
 
       {!overlayMode && (
-        <button
-          className="alt-card-expand"
-          onClick={() => onExpand?.(alternative.id)}
-          aria-expanded={false}
-          aria-controls={`alt-details-${alternative.id}`}
-        >
-          <span>{t('browse:card.showMore')}</span>
-          <svg
-            className="alt-card-expand-icon"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            aria-hidden="true"
+        <div className="alt-card-expand-row">
+          <button
+            className="alt-card-expand"
+            onClick={() => onExpand?.(alternative.id)}
+            aria-expanded={false}
+            aria-controls={`alt-details-${alternative.id}`}
           >
-            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
-          </svg>
-        </button>
+            <span>{t('browse:card.showMore')}</span>
+            <svg
+              className="alt-card-expand-icon"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+            </svg>
+          </button>
+          <button
+            className={`alt-card-compare-toggle ${isComparing ? 'active' : ''}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleCompare?.(alternative.id);
+            }}
+            aria-pressed={isComparing}
+            title={isComparing ? 'Aus Vergleich entfernen' : 'Zum Vergleich hinzufügen'}
+          >
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              {isComparing ? (
+                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+              ) : (
+                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+              )}
+            </svg>
+          </button>
+        </div>
       )}
 
       {overlayMode && (

--- a/src/components/BrowsePage.tsx
+++ b/src/components/BrowsePage.tsx
@@ -52,14 +52,17 @@ export default function BrowsePage() {
   const [sortBy, setSortBy] = useState<SortBy>('trustScore');
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [expandedCardIds, setExpandedCardIds] = useState<Set<string>>(new Set());
+  const [compareCardIds, setCompareCardIds] = useState<Set<string>>(new Set());
 
   const handleExpand = useCallback((id: string) => {
     setExpandedCardIds((prev) => {
       const next = new Set(prev);
       next.add(id);
+      // Also add all compared cards
+      compareCardIds.forEach((cid) => next.add(cid));
       return next;
     });
-  }, []);
+  }, [compareCardIds]);
 
   const handleCollapse = useCallback((id: string) => {
     setExpandedCardIds((prev) => {
@@ -92,6 +95,26 @@ export default function BrowsePage() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [expandedCardIds.size, handleCollapseAll]);
+
+  const handleToggleCompare = useCallback((id: string) => {
+    setCompareCardIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleOpenCompare = useCallback(() => {
+    setExpandedCardIds(new Set(compareCardIds));
+  }, [compareCardIds]);
+
+  const handleClearCompare = useCallback(() => {
+    setCompareCardIds(new Set());
+  }, []);
 
   const selectedFilters: SelectedFilters = useMemo(
     () => ({
@@ -284,7 +307,14 @@ export default function BrowsePage() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.4, delay: Math.min(0.1 + index * 0.05, 1) }}
               >
-                <AlternativeCard alternative={alternative} viewMode={viewMode} usVendorLookup={usVendorLookup} onExpand={handleExpand} />
+                <AlternativeCard
+                  alternative={alternative}
+                  viewMode={viewMode}
+                  usVendorLookup={usVendorLookup}
+                  onExpand={handleExpand}
+                  isComparing={compareCardIds.has(alternative.id)}
+                  onToggleCompare={handleToggleCompare}
+                />
               </motion.div>
             ))}
           </div>
@@ -317,6 +347,23 @@ export default function BrowsePage() {
           </motion.div>
         )}
       </motion.div>
+
+      {compareCardIds.size > 0 && expandedCardIds.size === 0 && (
+        <div className="compare-floating-bar">
+          <span className="compare-floating-count">
+            {compareCardIds.size} {compareCardIds.size === 1 ? 'Karte' : 'Karten'} zum Vergleich ausgewählt
+          </span>
+          <button className="compare-floating-open" onClick={handleOpenCompare}>
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M10 3H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zM9 9H5V5h4v4zm11-6h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zm-1 6h-4V5h4v4zm-9 4H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6a1 1 0 0 0-1-1zm-1 6H5v-4h4v4zm8-6c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0 8c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm1-4h-2v2h2v-2z" />
+            </svg>
+            Vergleichen
+          </button>
+          <button className="compare-floating-clear" onClick={handleClearCompare}>
+            ✕
+          </button>
+        </div>
+      )}
 
       {expandedCardIds.size > 0 && createPortal(
         <div

--- a/src/index.css
+++ b/src/index.css
@@ -127,7 +127,12 @@ body {
 }
 
 /* Typography */
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-family-heading);
   font-weight: 600;
   line-height: 1.3;
@@ -136,10 +141,21 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: 0.02em;
 }
 
-h1 { font-size: var(--font-size-3xl); }
-h2 { font-size: var(--font-size-2xl); }
-h3 { font-size: var(--font-size-xl); }
-h4 { font-size: var(--font-size-lg); }
+h1 {
+  font-size: var(--font-size-3xl);
+}
+
+h2 {
+  font-size: var(--font-size-2xl);
+}
+
+h3 {
+  font-size: var(--font-size-xl);
+}
+
+h4 {
+  font-size: var(--font-size-lg);
+}
 
 p {
   color: var(--text-secondary);
@@ -1125,7 +1141,7 @@ button:disabled {
   color: var(--text-secondary);
 }
 
-.reading-governance p + p {
+.reading-governance p+p {
   margin-top: var(--spacing-sm);
 }
 
@@ -1581,12 +1597,12 @@ button:disabled {
   transition: all var(--transition-fast);
 }
 
-.filter-checkbox:checked + .filter-checkbox-custom {
+.filter-checkbox:checked+.filter-checkbox-custom {
   background: var(--accent-primary);
   border-color: var(--accent-primary);
 }
 
-.filter-checkbox:focus-visible + .filter-checkbox-custom {
+.filter-checkbox:focus-visible+.filter-checkbox-custom {
   outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }
@@ -1610,7 +1626,7 @@ button:disabled {
   color: var(--text-primary);
 }
 
-.filter-checkbox:checked ~ .filter-label-text {
+.filter-checkbox:checked~.filter-label-text {
   color: var(--text-primary);
 }
 
@@ -2494,6 +2510,135 @@ button:disabled {
   color: var(--accent-primary);
 }
 
+/* Expand row: Show More + Compare side by side */
+.alt-card-expand-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: stretch;
+}
+
+.alt-card-expand-row .alt-card-expand {
+  flex: 1;
+}
+
+/* Compare toggle button on each card */
+.alt-card-compare-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  flex-shrink: 0;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.alt-card-compare-toggle:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.alt-card-compare-toggle.active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: white;
+}
+
+.alt-card-compare-toggle svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* Floating compare bar */
+.compare-floating-bar {
+  position: fixed;
+  bottom: var(--spacing-xl);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md) var(--spacing-sm) var(--spacing-lg);
+  background: var(--bg-card);
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-full);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.3),
+    0 0 0 1px var(--accent-primary-10);
+  animation: compareBarIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes compareBarIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+.compare-floating-count {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.compare-floating-open {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--accent-primary);
+  border: none;
+  border-radius: var(--radius-full);
+  color: white;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  white-space: nowrap;
+}
+
+.compare-floating-open:hover {
+  background: var(--accent-secondary);
+}
+
+.compare-floating-open svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.compare-floating-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full);
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.compare-floating-clear:hover {
+  background: var(--error-10);
+  border-color: var(--error);
+  color: var(--error);
+}
+
 /* ==========================================
    Card Overlay (Expanded Detail View)
    ========================================== */
@@ -2518,6 +2663,7 @@ button:disabled {
     opacity: 0;
     backdrop-filter: blur(0);
   }
+
   to {
     opacity: 1;
     backdrop-filter: blur(10px);
@@ -2577,6 +2723,7 @@ button:disabled {
     opacity: 0;
     transform: scale(0.92) translateY(20px);
   }
+
   to {
     opacity: 1;
     transform: scale(1) translateY(0);


### PR DESCRIPTION
### Motivation

Currently, clicking "Show more" expands the detailed content directly inline within the card. This results in **all cards below being pushed down** especially with longer details (Reservations, Trust Score breakdown, etc.), making it easy to lose track and requiring significant scrolling. Furthermore, you can only view **one card at a time**, which makes comparing alternatives difficult.

### What is changing?

#### 1. Overlay instead of Inline Expansion

When clicking "Show more," the card now opens as a **floating overlay** on top of the content:

* **Blur Backdrop** – The background is blurred and dimmed, keeping the full focus on the opened card.
* **No Content Shift** – The grid underneath stays in place; nothing jumps or shifts around.
* **Independent Scrolling** – For long details, you only scroll within the card itself, not the entire page.
* **Intuitive Controls** – Close via the "X" button, the Escape key, or by clicking the backdrop.

#### 2. Comparison Feature (New)

Each card now features a **"+" button** next to "Show more" for comparisons:

* Clicking **"+"** marks the card for comparison (the icon changes to a checkmark).
* A **floating bar** appears at the bottom of the screen showing the number of selected cards.
* Clicking **"Compare"** opens all selected cards **side-by-side** in the overlay.
* On smaller screens, the cards automatically stack vertically.

### Changed Files

* **`src/index.css`** – CSS for backdrop, overlay container, overlay card, animations, compare toggle button, floating compare bar, and responsive adjustments.
* **`src/components/AlternativeCard.tsx`** – New props `onExpand`, `overlayMode`, `isComparing`, and `onToggleCompare`. Details are now rendered in the overlay instead of inline.
* **`src/components/BrowsePage.tsx`** – State management for the overlay (`expandedCardIds`) and comparisons (`compareCardIds`), portal rendering, escape key handler, body scroll lock, and the floating compare bar.

### Note

This is a **proposal / proof-of-concept**. Personally, I find this layout much clearer because you don't lose context when expanding a card, and it provides the ability to compare alternatives directly side-by-side. I hope this contributes a helpful idea to the project! 🙂
