### PR TITLE
a11y: improve screen reader experience for badges and buttons

### DIFF
--- a/src/components/AlternativeCard.tsx
+++ b/src/components/AlternativeCard.tsx
@@ -390,6 +390,11 @@ export default function AlternativeCard({ alternative, viewMode, usVendorLookup 
             onClick={() => setUsVendorDetailsExpanded(!usVendorDetailsExpanded)}
             aria-expanded={usVendorDetailsExpanded}
             aria-controls={`alt-us-vendors-${alternative.id}`}
+            aria-label={
+              usVendorDetailsExpanded
+                ? t('browse:card.hideUSVendorDetailsFor', { name: alternative.name })
+                : t('browse:card.showUSVendorDetailsFor', { name: alternative.name })
+            }
           >
             <span>
               {usVendorDetailsExpanded
@@ -459,14 +464,19 @@ export default function AlternativeCard({ alternative, viewMode, usVendorLookup 
       </div>
 
       <div className="alt-card-badges">
-        <span className={`alt-card-badge alt-card-badge-pricing ${alternative.pricing}`}>
+        <span className="sr-only">
+          {[t(`common:pricing.${alternative.pricing}`), t(openSourceBadge.labelKey), ...visibleTags.slice(0, 2)].join(', ')}
+        </span>
+        <span className={`alt-card-badge alt-card-badge-pricing ${alternative.pricing}`} aria-hidden="true">
           {t(`common:pricing.${alternative.pricing}`)}
         </span>
-        <span className={`alt-card-badge alt-card-badge-openness ${openSourceBadge.className}`}>
+        <span className={`alt-card-badge alt-card-badge-openness ${openSourceBadge.className}`} aria-hidden="true">
           {t(openSourceBadge.labelKey)}
         </span>
         {visibleTags.slice(0, 2).map((tag) => (
-          <span key={tag} className="alt-card-badge alt-card-badge-tag">{tag}</span>
+          <span key={tag} className="alt-card-badge alt-card-badge-tag" aria-hidden="true">
+            {tag}
+          </span>
         ))}
       </div>
 
@@ -475,6 +485,11 @@ export default function AlternativeCard({ alternative, viewMode, usVendorLookup 
         onClick={() => setExpanded(!expanded)}
         aria-expanded={expanded}
         aria-controls={`alt-details-${alternative.id}`}
+        aria-label={
+          expanded
+            ? t('browse:card.showLessFor', { name: alternative.name })
+            : t('browse:card.showMoreFor', { name: alternative.name })
+        }
       >
         <span>{expanded ? t('browse:card.showLess') : t('browse:card.showMore')}</span>
         <svg
@@ -542,8 +557,11 @@ export default function AlternativeCard({ alternative, viewMode, usVendorLookup 
                 <div className="alt-detail-section">
                   <h4 className="alt-detail-title">{t('browse:card.tags')}</h4>
                   <div className="alt-detail-tags">
+                    <span className="sr-only">{visibleTags.join(', ')}</span>
                     {visibleTags.map((tag) => (
-                      <span key={tag} className="alt-detail-tag">{tag}</span>
+                      <span key={tag} className="alt-detail-tag" aria-hidden="true">
+                        {tag}
+                      </span>
                     ))}
                   </div>
                 </div>

--- a/src/i18n/locales/de/browse.json
+++ b/src/i18n/locales/de/browse.json
@@ -27,6 +27,8 @@
   "card": {
     "showMore": "Mehr anzeigen",
     "showLess": "Weniger anzeigen",
+    "showMoreFor": "Mehr über {{name}} anzeigen",
+    "showLessFor": "Weniger über {{name}} anzeigen",
     "about": "Über",
     "details": "Details",
     "founded": "Gegründet",
@@ -40,6 +42,8 @@
     "usVendorComparison": "US-Unternehmensprofil",
     "showUSVendorDetails": "Details anzeigen",
     "hideUSVendorDetails": "Details ausblenden",
+    "showUSVendorDetailsFor": "US-Unternehmensprofile für {{name}} anzeigen",
+    "hideUSVendorDetailsFor": "US-Unternehmensprofile für {{name}} ausblenden",
     "trustScorePending": "Trust-Score ausstehend",
     "trustScoreLabel": "Trust-Score: {{score}}/10",
     "trustScoreBreakdownTitle": "Trust-Score-Aufschluesselung",

--- a/src/i18n/locales/en/browse.json
+++ b/src/i18n/locales/en/browse.json
@@ -27,6 +27,8 @@
   "card": {
     "showMore": "Show more",
     "showLess": "Show less",
+    "showMoreFor": "Show more about {{name}}",
+    "showLessFor": "Show less about {{name}}",
     "about": "About",
     "details": "Details",
     "founded": "Founded",
@@ -40,6 +42,8 @@
     "usVendorComparison": "US Company Profile",
     "showUSVendorDetails": "Show details",
     "hideUSVendorDetails": "Hide details",
+    "showUSVendorDetailsFor": "Show US company profiles for {{name}}",
+    "hideUSVendorDetailsFor": "Hide US company profiles for {{name}}",
     "trustScorePending": "Trust-Score Pending",
     "trustScoreLabel": "Trust Score: {{score}}/10",
     "trustScoreBreakdownTitle": "Trust Score Breakdown",


### PR DESCRIPTION
## Summary
- Badges/tags (e.g. "Kostenlos", "Open Source", "email") were read by NVDA as a single concatenated string ("KostenlosOpen Sourceemailmail-server") because CSS `gap` does not produce text separation for screen readers. Added a `sr-only` span with comma-separated text and marked visual badge spans `aria-hidden` so screen readers announce them properly.
- "Show more" and "Show US vendor details" buttons now include the alternative name in their `aria-label` for context (e.g. "Mehr über MAILCOW anzeigen" instead of just "Mehr anzeigen").

## Changes
- `AlternativeCard.tsx`: sr-only text + aria-hidden on badge spans, aria-labels on toggle buttons
- `de/browse.json` / `en/browse.json`: 4 new translation keys for contextual aria-labels

## Test plan
- [x] NVDA + Firefox: navigate badges on a card, verify they are read as comma-separated list
- [x] NVDA + Firefox: tab to "Mehr anzeigen" / "Details anzeigen" buttons, verify alternative name is announced
- [x] Expand a card and verify detail-tags section is read correctly
- [ ] Visual regression: verify no visible changes in grid and list view
- [x] Test in both DE and EN language