### PR TITLE
fix(i18n): localize loading/error and compare UI texts

### DIFF
--- a/src/components/BrowsePage.tsx
+++ b/src/components/BrowsePage.tsx
@@ -23,7 +23,7 @@ export default function BrowsePage() {
     [usVendors],
   );
   const [searchParams, setSearchParams] = useSearchParams();
-  const { t, i18n } = useTranslation('browse');
+  const { t, i18n } = useTranslation(['browse', 'common']);
 
   const validCategoryIds = useMemo(
     () => new Set<string>(categories.map((category) => category.id)),
@@ -249,7 +249,7 @@ export default function BrowsePage() {
           <h1 className="browse-title">{t('title')}</h1>
           <p className="browse-subtitle">{t('subtitle')}</p>
         </div>
-        <div className="catalog-loading">Loading catalog data...</div>
+        <div className="catalog-loading">{t('common:status.loadingCatalog')}</div>
       </div>
     );
   }
@@ -261,7 +261,7 @@ export default function BrowsePage() {
           <h1 className="browse-title">{t('title')}</h1>
           <p className="browse-subtitle">{t('subtitle')}</p>
         </div>
-        <div className="catalog-error" role="alert">Data temporarily unavailable. Please try again later.</div>
+        <div className="catalog-error" role="alert">{t('common:status.dataUnavailable')}</div>
       </div>
     );
   }
@@ -351,13 +351,13 @@ export default function BrowsePage() {
       {compareCardIds.size > 0 && expandedCardIds.size === 0 && (
         <div className="compare-floating-bar">
           <span className="compare-floating-count">
-            {compareCardIds.size} {compareCardIds.size === 1 ? 'Karte' : 'Karten'} zum Vergleich ausgewählt
+            {t('compare.selectedCount', { count: compareCardIds.size })}
           </span>
           <button className="compare-floating-open" onClick={handleOpenCompare}>
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M10 3H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zM9 9H5V5h4v4zm11-6h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zm-1 6h-4V5h4v4zm-9 4H4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-6a1 1 0 0 0-1-1zm-1 6H5v-4h4v4zm8-6c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0 8c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm1-4h-2v2h2v-2z" />
             </svg>
-            Vergleichen
+            {t('compare.open')}
           </button>
           <button className="compare-floating-clear" onClick={handleClearCompare}>
             ✕
@@ -378,7 +378,7 @@ export default function BrowsePage() {
                 <button
                   className="card-overlay-close"
                   onClick={() => handleCollapse(alternative.id)}
-                  aria-label="Close"
+                  aria-label={t('overlay.close')}
                 >
                   <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />

--- a/src/components/DeniedPage.tsx
+++ b/src/components/DeniedPage.tsx
@@ -7,7 +7,7 @@ import type { Alternative } from '../types';
 
 export default function DeniedPage() {
   const { deniedAlternatives, loading, error } = useCatalog();
-  const { t } = useTranslation(['denied', 'data']);
+  const { t } = useTranslation(['denied', 'data', 'common']);
 
   if (loading) {
     return (
@@ -16,7 +16,7 @@ export default function DeniedPage() {
           <h1 className="denied-title">{t('denied:title')}</h1>
           <p className="denied-subtitle">{t('denied:subtitle')}</p>
         </div>
-        <div className="catalog-loading">Loading catalog data...</div>
+        <div className="catalog-loading">{t('common:status.loadingCatalog')}</div>
       </div>
     );
   }
@@ -28,7 +28,7 @@ export default function DeniedPage() {
           <h1 className="denied-title">{t('denied:title')}</h1>
           <p className="denied-subtitle">{t('denied:subtitle')}</p>
         </div>
-        <div className="catalog-error" role="alert">Data temporarily unavailable. Please try again later.</div>
+        <div className="catalog-error" role="alert">{t('common:status.dataUnavailable')}</div>
       </div>
     );
   }

--- a/src/components/FurtherReadingPage.tsx
+++ b/src/components/FurtherReadingPage.tsx
@@ -10,7 +10,7 @@ const sectionOrder: FurtherReadingSectionId[] = ['directories', 'publicCatalogue
 
 export default function FurtherReadingPage() {
   const { furtherReadingResources, loading, error } = useCatalog();
-  const { t } = useTranslation('furtherReading');
+  const { t } = useTranslation(['furtherReading', 'common']);
 
   const sections = useMemo(
     () =>
@@ -28,7 +28,7 @@ export default function FurtherReadingPage() {
           <h1 className="reading-title">{t('title')}</h1>
           <p className="reading-subtitle">{t('subtitle')}</p>
         </div>
-        <div className="catalog-loading">Loading catalog data...</div>
+        <div className="catalog-loading">{t('common:status.loadingCatalog')}</div>
       </div>
     );
   }
@@ -40,7 +40,7 @@ export default function FurtherReadingPage() {
           <h1 className="reading-title">{t('title')}</h1>
           <p className="reading-subtitle">{t('subtitle')}</p>
         </div>
-        <div className="catalog-error" role="alert">Data temporarily unavailable. Please try again later.</div>
+        <div className="catalog-error" role="alert">{t('common:status.dataUnavailable')}</div>
       </div>
     );
   }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -28,7 +28,7 @@ export default function LandingPage() {
   if (loading) {
     return (
       <div className="landing-page">
-        <div className="catalog-loading">Loading catalog data...</div>
+        <div className="catalog-loading">{t('common:status.loadingCatalog')}</div>
       </div>
     );
   }
@@ -36,7 +36,7 @@ export default function LandingPage() {
   if (error) {
     return (
       <div className="landing-page">
-        <div className="catalog-error" role="alert">Data temporarily unavailable. Please try again later.</div>
+        <div className="catalog-error" role="alert">{t('common:status.dataUnavailable')}</div>
       </div>
     );
   }

--- a/src/i18n/locales/de/browse.json
+++ b/src/i18n/locales/de/browse.json
@@ -5,6 +5,14 @@
   "catalogueComingSoonDesc": "Wir erstellen ein umfassendes Verzeichnis europäischer und Open-Source-Alternativen. Schau bald wieder vorbei oder trage zum Projekt bei.",
   "noResults": "Keine Ergebnisse gefunden",
   "noResultsDesc": "Keine Alternativen entsprechen deinen aktuellen Filtern. Versuche, deine Suche oder Filterkriterien anzupassen.",
+  "compare": {
+    "selectedCount_one": "{{count}} Karte zum Vergleich ausgewählt",
+    "selectedCount_other": "{{count}} Karten zum Vergleich ausgewählt",
+    "open": "Vergleichen"
+  },
+  "overlay": {
+    "close": "Schließen"
+  },
   "filters": {
     "searchPlaceholder": "Alternativen suchen...",
     "searchLabel": "Alternativen suchen",

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -29,6 +29,10 @@
     "light": "Hell",
     "dark": "Dunkel"
   },
+  "status": {
+    "loadingCatalog": "Katalogdaten werden geladen...",
+    "dataUnavailable": "Daten sind vorübergehend nicht verfügbar. Bitte versuche es später erneut."
+  },
   "meta": {
     "title": "Europäische Alternativen - Europäische & Open-Source-Software entdecken",
     "description": "Entdecke europäische und Open-Source-Alternativen zu US-Tech-Giganten. Unterstütze digitale Souveränität, Datenschutz und lokale Innovation.",

--- a/src/i18n/locales/en/browse.json
+++ b/src/i18n/locales/en/browse.json
@@ -5,6 +5,14 @@
   "catalogueComingSoonDesc": "We're building a comprehensive directory of European and open-source alternatives. Check back soon or contribute to the project.",
   "noResults": "No Results Found",
   "noResultsDesc": "No alternatives match your current filters. Try adjusting your search or filter criteria.",
+  "compare": {
+    "selectedCount_one": "{{count}} card selected for comparison",
+    "selectedCount_other": "{{count}} cards selected for comparison",
+    "open": "Compare"
+  },
+  "overlay": {
+    "close": "Close"
+  },
   "filters": {
     "searchPlaceholder": "Search alternatives...",
     "searchLabel": "Search alternatives",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -29,6 +29,10 @@
     "light": "Light",
     "dark": "Dark"
   },
+  "status": {
+    "loadingCatalog": "Loading catalog data...",
+    "dataUnavailable": "Data temporarily unavailable. Please try again later."
+  },
   "meta": {
     "title": "European Alternatives - Discover European & Open Source Software",
     "description": "Discover European and open-source alternatives to US tech giants. Support digital sovereignty, data privacy, and local innovation.",


### PR DESCRIPTION
## Summary

This PR fixes i18n inconsistencies in the UI by replacing hardcoded strings with translation keys.

## What Changed

- Localized loading and error states in:
- `src/components/LandingPage.tsx`
- `src/components/BrowsePage.tsx`
- `src/components/DeniedPage.tsx`
- `src/components/FurtherReadingPage.tsx`
- Localized compare-bar texts on the browse page:
- selected count (`1 card` / `n cards`)
- compare button label
- overlay close `aria-label`
- Added new translation keys in:
- `src/i18n/locales/en/common.json`
- `src/i18n/locales/de/common.json`
- `src/i18n/locales/en/browse.json`
- `src/i18n/locales/de/browse.json`

## Why

Users could see mixed-language UI (hardcoded EN/DE strings) despite active locale selection.  
This PR ensures those UI texts now follow the selected app language consistently.

## Validation

- `npm run lint` ✅
- `npm test` ✅ (`160 passed`, `5 skipped`)

## Notes

- No business logic changes.
- No API changes.
- Accessibility improved for localized overlay close label.
