### PR TITLE
Matrix coverage chips: 4-state tones + email/messaging presence lists

### DIFF
--- a/scripts/migrations/082-matrix-coverage-mode-email-messaging.sql
+++ b/scripts/migrations/082-matrix-coverage-mode-email-messaging.sql
@@ -1,0 +1,42 @@
+-- Migration 082: Put email + messaging presence-list criteria into coverage display mode.
+--
+-- Migration 063 assigned `display_mode = 'coverage'` by criterion-key naming
+-- (`supported_%`, `%_features`, plus a hardcoded list). That heuristic missed
+-- email's presence-list multi-enums, which do not follow that naming, so those
+-- cells only render the options an entry HAS (in their static per-option tone)
+-- and never show what is missing. In coverage mode every option renders:
+-- supported (green / amber for a tradeoff option) or absent (red).
+--
+-- This migration flips only reviewed, genuine presence lists. It deliberately
+-- does NOT blanket-convert every multi-enum: long enumeration/summary lists
+-- (fit_profiles, format/codec/region/SDK-language lists) would become red-heavy
+-- noise under coverage and need per-category review instead.
+
+UPDATE `matrix_criteria`
+SET `display_mode` = 'coverage'
+WHERE `value_type` = 'multi_enum'
+  AND (
+    (
+      `category_id` = 'email'
+      AND `criterion_key` IN (
+        'standard_mail_protocols',
+        'server_side_filters',
+        'domain_authentication_controls',
+        'anti_abuse_protection',
+        'tracker_remote_content_protection',
+        'compliance_profiles',
+        'migration_import_sources',
+        'contacts_calendar_export',
+        'productivity_suite_scope'
+      )
+    )
+    OR (
+      `category_id` = 'messaging'
+      AND `criterion_key` IN (
+        'group_admin_tools'
+      )
+    )
+  );
+
+INSERT INTO `schema_migrations` (`version`)
+VALUES ('082-matrix-coverage-mode-email-messaging');

--- a/src/components/CategoryMatrixView.tsx
+++ b/src/components/CategoryMatrixView.tsx
@@ -2141,7 +2141,9 @@ function renderFullCoverageOptions(
     <span className="category-matrix-option-list category-matrix-option-list--coverage">
       {criterion.options.map((option) =>
         renderOption(criterion, option.id, t, {
-          tone: selected.has(option.id) ? "positive" : "negative",
+          tone: selected.has(option.id)
+            ? coveragePresentTone(option.displayTone)
+            : "negative",
         }),
       )}
       {unknownSelected.map((optionId) =>
@@ -2149,6 +2151,19 @@ function renderFullCoverageOptions(
       )}
     </span>
   );
+}
+
+// Tone for a *supported* option in a coverage row. Presence is the primary
+// signal, so a supported option with a neutral (or unset) catalogue tone still
+// reads as positive/green — matching the "present = good" reading of coverage
+// rows (e.g. a mail service that offers POP3 or an app that runs on iOS). A
+// tradeoff/warning/negative tone is preserved so a supported-but-cautionary
+// option stays amber or red rather than being painted green. Absent options are
+// always negative (red), handled by the caller.
+function coveragePresentTone(
+  tone: MatrixDisplayTone | undefined,
+): MatrixDisplayTone {
+  return tone === undefined || tone === "neutral" ? "positive" : tone;
 }
 
 type MatrixBooleanTone = "positive" | "warning" | "negative" | "neutral";

--- a/tests/category-matrix-legend-and-popover.test.ts
+++ b/tests/category-matrix-legend-and-popover.test.ts
@@ -144,6 +144,7 @@ function fixture(): CategoryMatrixApiResponse {
           options: [
             { id: "reactions", label: "Reactions", displayTone: "positive" },
             { id: "threads", label: "Threads", displayTone: "positive" },
+            { id: "polls", label: "Polls", displayTone: "tradeoff" },
           ],
         }),
       ],
@@ -185,7 +186,7 @@ function fixture(): CategoryMatrixApiResponse {
       },
       reactions_threads: {
         status: "verified",
-        value: ["reactions"],
+        value: ["reactions", "polls"],
       },
     }),
     matrixAlternative("alpha-chat", "Alpha Chat", {
@@ -492,6 +493,19 @@ describe("matrix cell color-independence", () => {
     );
     expect(html).toMatch(
       /category-matrix-option--negative[^>]*aria-label="Negative \/ not supported: Threads"/u,
+    );
+  });
+
+  it("keeps a supported-but-tradeoff coverage option amber, not green", async () => {
+    const html = await renderMatrix();
+
+    // Presence upgrades neutral options to green, but a supported option whose
+    // catalogue tone is a tradeoff must stay amber so it is not overstated.
+    expect(html).toMatch(
+      /category-matrix-option--tradeoff[^>]*aria-label="[^"]*Polls"/u,
+    );
+    expect(html).not.toMatch(
+      /category-matrix-option--positive[^>]*aria-label="[^"]*Polls"/u,
     );
   });
 });

--- a/tests/matrix-coverage-mode-email-messaging-migration.test.ts
+++ b/tests/matrix-coverage-mode-email-messaging-migration.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  new URL(
+    "../scripts/migrations/082-matrix-coverage-mode-email-messaging.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("matrix coverage-mode email/messaging migration", () => {
+  it("flips the reviewed email presence lists to coverage", () => {
+    expect(migration).toMatch(
+      /UPDATE\s+`matrix_criteria`[\s\S]*`display_mode`\s*=\s*'coverage'/i,
+    );
+    expect(migration).toContain("`value_type` = 'multi_enum'");
+    for (const key of [
+      "standard_mail_protocols",
+      "server_side_filters",
+      "domain_authentication_controls",
+      "anti_abuse_protection",
+      "tracker_remote_content_protection",
+      "compliance_profiles",
+      "migration_import_sources",
+      "contacts_calendar_export",
+      "productivity_suite_scope",
+    ]) {
+      expect(migration).toContain(`'${key}'`);
+    }
+  });
+
+  it("flips the messaging group-admin gap and records the migration", () => {
+    expect(migration).toContain("'group_admin_tools'");
+    expect(migration).toContain("`category_id` = 'messaging'");
+    expect(migration).toContain(
+      "'082-matrix-coverage-mode-email-messaging'",
+    );
+  });
+
+  it("does not blanket-convert summary lists like fit_profiles", () => {
+    expect(migration).not.toContain("'fit_profiles'");
+    expect(migration).not.toMatch(/LIKE\s+'%/i);
+  });
+});


### PR DESCRIPTION
## What

Two linked changes to how matrix **coverage** cells render (the "green if supported / red if missing" rows).

### 1. Renderer: 4-state coverage chips (`CategoryMatrixView.tsx`)
`renderFullCoverageOptions` was binary — every supported option forced to green, every absent one red. Now a supported option keeps its own catalogue tone:

- supported + positive/neutral → **green** (presence is the signal — iOS, POP3, folders read as green even though tagged neutral)
- supported + tradeoff/warning → **amber** (e.g. Exchange ActiveSync, Drive/Office in a suite — no longer overstated as green)
- supported + negative → **red**
- absent → **red**

This makes the per-option tones the data already carries actually matter in the cell (previously only the filter dropdown used them).

### 2. Migration 082: flip email/messaging presence lists to coverage
Migration 063 assigned coverage mode by criterion-key naming (`supported_%`, `%_features`, a hardcoded list), which missed email's presence lists because their keys don't match. This flips them explicitly:

- **email:** standard mail protocols, server-side filters, domain auth controls, anti-abuse, tracker/remote-content protection, compliance profiles, import sources, contacts/calendar export, productivity suite scope
- **messaging:** group_admin_tools (the one clear gap vs the rest of that category)

Deliberately **not** a blanket flip of all 336 default multi_enums — long enumeration/summary lists (`fit_profiles`, format/codec/region/SDK-language lists) would become red-heavy noise and need per-category editorial review.

## Prod state
Migration 082 has **already been applied to the prod DB** (10 rows, verified `coverage`, snapshot kept for revert). The API serves `display_mode` from the DB behind a 300s cache, so the data change is live within 5 min. This PR carries the migration file for the record + the renderer that upgrades those cells from binary to 4-state on deploy.

## Tests
- Extended `category-matrix-legend-and-popover.test.ts` with a supported-but-tradeoff → amber case.
- Added `matrix-coverage-mode-email-messaging-migration.test.ts`.
- Full suite green (2169 passed), tsc + lint clean.

## Follow-up (not in this PR)
"Coverage by default for multi_enum" would be sounder than the name heuristic but needs a per-category pass to opt out summary/open-ended lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMCnQU6Sk2WxGeFXMJZqMp